### PR TITLE
add get video view count tool to youtube agent

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,12 +1,13 @@
 import asyncio
 
-from autogen_agentchat.task import Console, TextMentionTermination
+from autogen_agentchat.ui import Console
+from autogen_agentchat.conditions import TextMentionTermination
 from autogen_agentchat.teams import RoundRobinGroupChat
 
 # ensure autogen_ext is installed; e.g., pip install 'autogen_ext[openai]==0.4.0.dev8'
 # if you want to use a different model client (e.g., anthropic), you can install
 # the relevant extension instead. Also ensure you've set your OPENAI_API_KEY environment variable.
-from autogen_ext.models import OpenAIChatCompletionClient
+from autogen_ext.models.openai import OpenAIChatCompletionClient
 from autogen_yt_agent import YouTubeAgent
 
 

--- a/src/autogen_yt_agent/_agent.py
+++ b/src/autogen_yt_agent/_agent.py
@@ -4,7 +4,13 @@ from autogen_agentchat.agents import AssistantAgent
 from autogen_core.components.models import ChatCompletionClient
 from autogen_core.components.tools import Tool
 
-from ._tools import extract_audio, get_video_length, transcribe_audio_with_timestamps, download_youtube_video
+from ._tools import (
+    extract_audio,
+    get_video_length,
+    transcribe_audio_with_timestamps,
+    download_youtube_video,
+    get_video_views,
+)
 
 
 class YouTubeAgent(AssistantAgent):
@@ -13,10 +19,11 @@ class YouTubeAgent(AssistantAgent):
         name: str,
         model_client: ChatCompletionClient,
         *,
-        tools: List[Tool | Callable[..., Any] | Callable[..., Awaitable[Any]]] | None = None,
+        tools: (List[Tool | Callable[..., Any] | Callable[..., Awaitable[Any]]] | None) = None,
         description: str = "An agent that can download and process YouTube videos.",
-        system_message: str
-        | None = "You are a helpful agent that is an expert at processing YouTube videos. Reply with TERMINATE to end the conversation.",
+        system_message: (
+            str | None
+        ) = "You are a helpful agent that is an expert at processing YouTube videos. Reply with TERMINATE to end the conversation.",
     ):
         super().__init__(
             name=name,
@@ -27,6 +34,7 @@ class YouTubeAgent(AssistantAgent):
                 download_youtube_video,
                 extract_audio,
                 transcribe_audio_with_timestamps,
+                get_video_views,
             ],
             description=description,
             system_message=system_message,

--- a/src/autogen_yt_agent/_agent.py
+++ b/src/autogen_yt_agent/_agent.py
@@ -1,8 +1,8 @@
 from typing import Any, Awaitable, Callable, List
 
 from autogen_agentchat.agents import AssistantAgent
-from autogen_core.components.models import ChatCompletionClient
-from autogen_core.components.tools import Tool
+from autogen_core.models import ChatCompletionClient
+from autogen_core.tools import Tool
 
 from ._tools import (
     extract_audio,

--- a/src/autogen_yt_agent/_tools.py
+++ b/src/autogen_yt_agent/_tools.py
@@ -34,6 +34,22 @@ def download_youtube_video(url: str, output_path: str) -> str:
         return f"An error occurred: {e}"
 
 
+def get_video_views(url: str) -> str:
+    """
+    Returns the number of views a video has.
+
+    :param url: URL of the YouTube video.
+    :return: the number of views the video has.
+    """
+    try:
+        with yt_dlp.YoutubeDL() as ydl:
+            info = ydl.extract_info(url, download=False)
+            return f"The video has {info['view_count']} views."
+        return "Test"
+    except Exception as e:
+        return f"An error occurred: {e}"
+
+
 def transcribe_audio_with_timestamps(audio_path: str) -> str:
     """
     Transcribes the audio file with timestamps using the Whisper model.
@@ -79,4 +95,5 @@ __all__ = [
     "download_youtube_video",
     "transcribe_audio_with_timestamps",
     "get_video_length",
+    "get_video_views",
 ]

--- a/src/autogen_yt_agent/_tools.py
+++ b/src/autogen_yt_agent/_tools.py
@@ -45,7 +45,6 @@ def get_video_views(url: str) -> str:
         with yt_dlp.YoutubeDL() as ydl:
             info = ydl.extract_info(url, download=False)
             return f"The video has {info['view_count']} views."
-        return "Test"
     except Exception as e:
         return f"An error occurred: {e}"
 


### PR DESCRIPTION
Hey Gagan - I am a fellow engineer at MSFT whose team is beginning work on agentic AI with HLS (Health Life Sciences).

To get acclimated to working with such technologies, I decided to try to add a simple tool to your YouTube agent, which allows the agent to get the view count from the info yt_dlp returns.

Please let me know if you would consider this a good addition to the agent and if you have any feedback on the implementation and further functionality!